### PR TITLE
Remove python from dh invocation's list of --with parameters.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@  --with autoreconf,python2,systemd
+	dh $@  --with autoreconf,systemd
 


### PR DESCRIPTION
At this time, we don't use debhelper's python support, as we aren't
generating debian python packages.