### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS=-I m4
+
 bin_SCRIPTS = scripts/bin/*
 
 pyutilsdir=$(libdir)/sonic

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_INIT([sonic-nas-linux], [1.0.1], [sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIRS([m4])
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.